### PR TITLE
fix:로그인 기능 완성 ver1.0

### DIFF
--- a/src/components/commons/Button.jsx
+++ b/src/components/commons/Button.jsx
@@ -1,26 +1,47 @@
+import React from "react";
+import LoadingSpinner from "../commons/LoadingSpinner"; // Spinner 컴포넌트 import
+
 const Button = ({
   buttonDisabled,
   className,
   color,
   onClick,
   children,
+  onKeyDown,
+  isLoading, // 로딩 상태 prop 추가
+  loadingText = "전송 중", // 로딩 시 표시할 텍스트 (기본값 설정)
   ...props
 }) => {
   const colorClasses = {
     undpoint: "bg-undpoint text-white",
     unddisabled: "bg-unddisabled text-undtextgray",
-
     // 필요한 색상 추가
+  };
+
+  // 버튼 내용을 렌더링하는 함수
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center gap-2">
+          <LoadingSpinner size="sm" />
+          <span className="text-base">{loadingText}</span>
+        </div>
+      );
+    }
+    return children;
   };
 
   return (
     <button
       {...props}
+      onKeyDown={onKeyDown}
       onClick={onClick}
-      disabled={buttonDisabled}
-      className={`${colorClasses[color]} ${className}`}
+      disabled={buttonDisabled || isLoading} // isLoading일 때도 버튼 비활성화
+      className={`${colorClasses[color]} ${className} ${
+        isLoading ? "cursor-not-allowed" : ""
+      }`}
     >
-      {children}
+      {renderContent()}
     </button>
   );
 };

--- a/src/components/commons/Calendar.jsx
+++ b/src/components/commons/Calendar.jsx
@@ -110,6 +110,10 @@ const Calendar = ({
     }
   };
 
+  const handleChangeRaw = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div className="text-start w-full">
       <label className="text-undtextdark flex justify-between" htmlFor={id}>
@@ -118,6 +122,7 @@ const Calendar = ({
       </label>
       <div className="w-full">
         <DatePicker
+          onChangeRaw={handleChangeRaw}
           formatWeekDay={(nameOfDay) => nameOfDay.substring(0, 1)}
           dateFormat="yyyy-MM-dd"
           shouldCloseOnSelect
@@ -132,7 +137,9 @@ const Calendar = ({
           showMonthDropdown
           dropdownMode="select"
           wrapperClassName="w-full"
-          className={`block p-2.5 w-full rounded-full ${className || ""}`}
+          className={`block p-2.5 w-full rounded-full cursor-pointer ${
+            className || ""
+          }`}
           placeholderText="생년월일을 선택해주세요"
           dayClassName={(d) => {
             if (!is14YearsOld(d)) {

--- a/src/components/commons/Input.jsx
+++ b/src/components/commons/Input.jsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 // 공통 입력 필드 컴포넌트
-const MyPageInput = forwardRef((props, ref) => {
+const Input = forwardRef((props, ref) => {
   const {
     id,
     labeltext,
@@ -16,10 +16,12 @@ const MyPageInput = forwardRef((props, ref) => {
     children,
     readonly,
     onInput,
+    onKeyDown,
+    width,
   } = props;
 
   return (
-    <div className="text-start w-full">
+    <div className={`text-start ${width || "w-full"}`}>
       <label className={` text-undtextdark flex justify-between`} htmlFor={id}>
         <div>{labeltext}</div>
         <div className="text-sm">{children}</div>
@@ -41,11 +43,12 @@ const MyPageInput = forwardRef((props, ref) => {
         ref={ref}
         readOnly={readonly}
         onInput={onInput}
+        onKeyDown={onKeyDown}
       />
     </div>
   );
 });
 
-MyPageInput.displayName = "MyPageInput";
+Input.displayName = "Input";
 
-export default MyPageInput;
+export default Input;

--- a/src/components/commons/LoadingSpinner.jsx
+++ b/src/components/commons/LoadingSpinner.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const LoginSpinner = ({ size = "sm", className = "" }) => {
+  const sizeClasses = {
+    sm: "w-4 h-4",
+    md: "w-6 h-6",
+    lg: "w-8 h-8",
+  };
+
+  return (
+    <div className={`inline-block ${sizeClasses[size]} ${className}`}>
+      <div className="w-full h-full border-2 border-b-transparent border-undtextgray rounded-full animate-spin" />
+    </div>
+  );
+};
+
+export default LoginSpinner;

--- a/src/components/member/LoginComponent.jsx
+++ b/src/components/member/LoginComponent.jsx
@@ -67,11 +67,11 @@ const LoginComponent = () => {
     });
   };
 
-  // const handleKeyDown = (e) => {
-  //   if (e.key === "Enter") {
-  //     handleClickLogin;
-  //   }
-  // };
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      handleClickLogin();
+    }
+  };
 
   // 전체 동의 체크박스 핸들러
   const handleAllAgree = (checked) => {
@@ -117,7 +117,7 @@ const LoginComponent = () => {
   };
 
   return (
-    <div className="flex flex-col p-8 h-full gap-14">
+    <div className="flex flex-col p-6 h-full gap-14">
       <div className="flex justify-center mt-10 w-full">
         <img src="/public/assets/logos/gongchaekWithTextLogin.png" alt="" />
       </div>
@@ -128,6 +128,7 @@ const LoginComponent = () => {
           type="text"
           name="email"
           value={loginParam.email}
+          onKeyDown={handleKeyDown}
           onChange={handleChange}
           placeholder={"아이디를 입력해 주세요."}
         />
@@ -137,6 +138,7 @@ const LoginComponent = () => {
           type="password"
           name="pw"
           value={loginParam.pw}
+          onKeyDown={handleKeyDown}
           onChange={handleChange}
           placeholder={"비밀번호를 입력해 주세요."}
         />
@@ -153,7 +155,7 @@ const LoginComponent = () => {
         </Button>
         <Button className="text-undpoint py-3 rounded-full font-semibold w-full">
           <img
-            className="rounded-full h-[45.6px]"
+            className="rounded-full"
             src="/assets/img/kakao_login.png"
             alt=""
           />

--- a/src/components/member/SignupStepOne.jsx
+++ b/src/components/member/SignupStepOne.jsx
@@ -23,6 +23,7 @@ function SignupStepOne({ onEmailVerified }) {
     validCheckUsername: false,
   };
 
+  const [isLoading, setIsLoading] = useState(false);
   const [email, setEmail] = useState(initialState.email);
   const [isValid, setIsValid] = useState(initialState.isValid);
   const [validText, setValidText] = useState(initialState.validText);
@@ -95,6 +96,7 @@ function SignupStepOne({ onEmailVerified }) {
   // 인증번호 전송
   const handleButtonHandler = async () => {
     try {
+      setIsLoading(true);
       const response = await sendVerificationEmail(email);
       if (response.result) {
         setIsVerified(false); // 이전 인증 상태 초기화
@@ -110,6 +112,8 @@ function SignupStepOne({ onEmailVerified }) {
       }
     } catch (err) {
       setValidText(err.message);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -154,6 +158,7 @@ function SignupStepOne({ onEmailVerified }) {
   // 인증번호 확인
   const verifyCode = async (code) => {
     try {
+      setIsLoading(true); // 로딩 상태 추가
       const response = await verifyEmailCode(email, code);
       setIsVerified(response.result);
       setVerificationMessage(response.message);
@@ -166,6 +171,8 @@ function SignupStepOne({ onEmailVerified }) {
     } catch (err) {
       setIsVerified(false);
       setVerificationMessage(err.message);
+    } finally {
+      setIsLoading(false); // 로딩 상태 해제
     }
   };
 
@@ -255,13 +262,13 @@ function SignupStepOne({ onEmailVerified }) {
           </div>
 
           {validNum && (
-            <div>
-              <div>
+            <div className="w-full">
+              <div className="w-full">
                 <p className="mt-14 mb-3 text-sm font-semibold">
                   이메일로 전송된 인증번호를 입력해 주세요.
                 </p>
                 <CountdownTimer onTimeEnd={handleTimeEnd} restart={timerKey} />
-                <div className="flex justify-between gap-5">
+                <div className="w-full flex justify-between gap-5">
                   {[
                     { ref: firstInputRef, nextRef: secondInputRef },
                     { ref: secondInputRef, nextRef: thirdInputRef },
@@ -271,7 +278,8 @@ function SignupStepOne({ onEmailVerified }) {
                     <Input
                       key={index}
                       ref={input.ref}
-                      className={`w-14 text-center font-bold text-undtextdark border border-undtextgray
+                      width={"w-1/4"}
+                      className={`w-full text-center font-bold text-undtextdark border border-undtextgray
                         ${
                           validTimeExpired
                             ? "border border-red-500"
@@ -308,9 +316,12 @@ function SignupStepOne({ onEmailVerified }) {
               <Button
                 onClick={handleButtonHandler}
                 className="py-2.5 rounded-full w-full"
-                buttonDisabled={!isValid || !validCheckUsername}
+                buttonDisabled={!isValid || !validCheckUsername || isLoading}
+                isLoading={isLoading}
                 color={
-                  !isValid || !validCheckUsername ? "unddisabled" : "undpoint"
+                  !isValid || !validCheckUsername || isLoading
+                    ? "unddisabled"
+                    : "undpoint"
                 }
               >
                 인증번호 전송
@@ -320,7 +331,8 @@ function SignupStepOne({ onEmailVerified }) {
               <Button
                 onClick={handleButtonHandler}
                 className="py-2.5 rounded-full w-full"
-                color="undpoint"
+                color={`${!isLoading ? "undpoint" : "unddisabled"}`}
+                isLoading={isLoading}
               >
                 인증번호 재전송
               </Button>

--- a/src/components/modal/commons/BasicModal.jsx
+++ b/src/components/modal/commons/BasicModal.jsx
@@ -2,12 +2,13 @@ import React, { useRef } from "react";
 import { PiXCircleFill } from "react-icons/pi";
 import Button from "../../commons/Button";
 
-const SignupModal = ({
+const BasicModal = ({
   isOpen,
   confirmText,
   Bottom,
   onConfirm,
   onClose,
+  onBackgroundClick, // 새로 추가된 prop
   children,
   className,
   bgClassName,
@@ -17,9 +18,15 @@ const SignupModal = ({
 
   const closeModal = (e) => {
     if (e.target === modalBackground.current) {
-      onClose();
+      // 커스텀 핸들러가 있으면 그것을 사용, 없으면 기본 onClose 사용
+      if (onBackgroundClick) {
+        onBackgroundClick();
+      } else {
+        onClose();
+      }
     }
   };
+
   return (
     <div
       className={`fixed inset-0 z-50 bg-black bg-opacity-50 ${
@@ -55,4 +62,4 @@ const SignupModal = ({
   );
 };
 
-export default SignupModal;
+export default BasicModal;

--- a/src/layouts/MemberLayout.jsx
+++ b/src/layouts/MemberLayout.jsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 const MemberLayout = ({ children, value }) => {
   return (
-    <div className="pt-10 px-8 pb-8 h-full flex flex-col">
+    <div className="pt-10 px-6 pb-6 h-full flex flex-col">
       <div className="grid grid-cols-MemberLayoutGrid mb-10">
         <div></div>
         <div className=" font-bold text-undpoint text-xl">{value}</div>


### PR DESCRIPTION
1. 모든 페이지에 메시지 끝에 .온점 없는 걸로 통일
2. 취향 선택 페이지에 구성 변경
3. 로그인 페이지 엔터키로 로그인 기능 추가
4. 취향 선택하고 회원가입 버튼 클릭하면 생기는 모달창 바깥부분 클릭시 그대로 취향 선택 페이지에 머물던 버그 수정
5. 인증번호 전송 / 재전송 연속 클릭 막기
6. 생년월일 직접 입력 막고 달력에서 선택만 가능하도록 수정
7. 회원가입 후 로그인 된 상태로 내 책장으로 가도록 수정